### PR TITLE
Fix silent checkpoint key mismatch in PromptPAR test scripts (vis_embed -> visual_embed)

### DIFF
--- a/PromptPAR/test_example.py
+++ b/PromptPAR/test_example.py
@@ -51,7 +51,14 @@ def main(args):
     model = TransformerClassifier(clip_model,train_set.attr_num,train_set.attributes)
     # 
     #CUDA_VISIBLE_DEVICES=4 python eval.py RAPV1 --checkpoint --dir /data1/Code/jinjiandong/OpenPAR-main/PromptPAR/logs/PETA/2024-05-23_14_59_25/epoch21.pth
-    model.load_state_dict(checkpoint['model_state_dict'], strict=False)
+    # released checkpoints (e.g. PA100k) name the visual projection layer 'vis_embed',
+    # while the current model registers it as 'visual_embed'; remap so the trained
+    # weights are actually loaded instead of being silently dropped by strict=False
+    state_dict = {k.replace('vis_embed.', 'visual_embed.'): v
+                  for k, v in checkpoint['model_state_dict'].items()}
+    load_result = model.load_state_dict(state_dict, strict=False)
+    if load_result.missing_keys:
+        print(f"Warning: missing keys when loading checkpoint: {load_result.missing_keys}")
     if torch.cuda.is_available():
         model = model.cuda()
         clip_model=clip_model.cuda()

--- a/PromptPAR/test_in_custom.py
+++ b/PromptPAR/test_in_custom.py
@@ -71,7 +71,14 @@ def main(args, image_root):
         checkpoint = torch.load(args.dir, map_location=device)
         clip_model = build_model(checkpoint['ViT_model'])
         model = TransformerClassifier(clip_model, attr_num, attributes)
-        model.load_state_dict(checkpoint['model_state_dict'], strict=False)
+        # released checkpoints (e.g. PA100k) name the visual projection layer 'vis_embed',
+        # while the current model registers it as 'visual_embed'; remap so the trained
+        # weights are actually loaded instead of being silently dropped by strict=False
+        state_dict = {k.replace('vis_embed.', 'visual_embed.'): v
+                      for k, v in checkpoint['model_state_dict'].items()}
+        load_result = model.load_state_dict(state_dict, strict=False)
+        if load_result.missing_keys:
+            print(f"Warning: missing keys when loading checkpoint: {load_result.missing_keys}")
         model = model.to(device)
         clip_model = clip_model.to(device)
     else:


### PR DESCRIPTION
Thanks for releasing the code and checkpoints, PromptPAR has been very useful in my work. While testing the released checkpoints I noticed they can't load the visual projection layer with the current code, because the layer was renamed. The checkpoint stores it as `vis_embed`, but `base_block.py` (since 4743846, added in #56) registers it as `visual_embed`. Since the test scripts load with `strict=False`, the trained weights are silently skipped and the layer stays randomly initialized, so predictions from the released checkpoints are degraded. I think this is the cause of the wrong predictions reported in #43.

To reproduce, load `PA100k_Checkpoint.pth` from the README link and check the result of `load_state_dict`:

```python
result = model.load_state_dict(checkpoint['model_state_dict'], strict=False)
print(result.missing_keys)
# ['visual_embed.weight', 'visual_embed.bias']
```

The checkpoint contains `vis_embed.weight` (768x768) and `vis_embed.bias` (768,), which match the shapes of `visual_embed` exactly. On a set of real pedestrian crops, loading the trained weights instead of the random ones changed about 4% of the attribute decisions (e.g. backpack probability 0.01 vs 0.70 on the same image).

This PR remaps the old key name in `test_example.py` and `test_in_custom.py` before calling `load_state_dict`, and prints a warning if any keys are still missing so this kind of mismatch is visible in the future.

I checked all three checkpoints from the README: PA100k and PETA both store `vis_embed` and are fixed by this remap. The RAP1 checkpoint has no `vis_embed`/`visual_embed` weights at all (it seems to predate the projection layer), so this remap doesn't change anything for it.

Related to #43 and #56. Happy to adjust anything if you'd prefer a different approach (e.g. renaming the layer back instead of remapping the keys).
